### PR TITLE
feat: modernize matchers, add toolchain/test groups, force chore(deps) prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Shareable Renovate presets for jacaudi repositories.
 
 | Preset | Description |
 |--------|-------------|
-| `base` | Base config with common settings and GitHub Actions grouping |
-| `go` | Go projects - runs `go mod tidy` |
+| `base` | Base config with common settings, `chore(deps):` commit prefix, and GitHub Actions grouping |
+| `go` | Go projects - runs `go mod tidy`, groups ginkgo/gomega and Go toolchain bumps, matches `go-version` inputs in reusable workflow calls |
 | `python` | Python - pins to n-1 version |
-| `kubernetes` | K8s operators - groups k8s.io packages |
+| `kubernetes` | K8s operators - groups `k8s.io/*` and `sigs.k8s.io/controller-runtime` |
 | `helm` | Helm charts - groups chart dependencies |
 | `automerge` | Auto-merge patch updates after 3 days |
 | `fork` | Enable processing on forked repos |

--- a/base.json
+++ b/base.json
@@ -18,6 +18,8 @@
   ],
   "semanticCommitType": "chore",
   "semanticCommitScope": "deps",
+  "commitMessagePrefix": "chore(deps):",
+  "branchPrefix": "renovate/",
   "packageRules": [
     {
       "description": "Group all GitHub Actions updates",

--- a/go.json
+++ b/go.json
@@ -1,5 +1,27 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Go-specific Renovate preset",
-  "postUpdateOptions": ["gomodTidy"]
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "description": "Group Ginkgo and Gomega test framework bumps together",
+      "matchPackageNames": ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"],
+      "groupName": "test-libraries"
+    },
+    {
+      "description": "Group Go toolchain bumps (go.mod directive, golang Docker image, setup-go version)",
+      "matchPackageNames": ["go", "golang"],
+      "groupName": "go-toolchain"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Match go-version inputs to reusable workflows (native github-actions manager only matches direct setup-go usage)",
+      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": ["go-version:\\s*['\"]?(?<currentValue>[0-9.]+)['\"]?"],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version"
+    }
+  ]
 }

--- a/kubernetes.json
+++ b/kubernetes.json
@@ -4,12 +4,7 @@
   "packageRules": [
     {
       "description": "Group Kubernetes client libraries (must be updated together)",
-      "matchPackagePatterns": ["^k8s.io/"],
-      "groupName": "kubernetes-client-libraries"
-    },
-    {
-      "description": "Group controller-runtime with k8s libraries",
-      "matchPackagePatterns": ["^sigs.k8s.io/controller-runtime$"],
+      "matchPackageNames": ["/^k8s\\.io//", "sigs.k8s.io/controller-runtime"],
       "groupName": "kubernetes-client-libraries"
     }
   ]


### PR DESCRIPTION
## Summary
- `kubernetes.json`: replace deprecated `matchPackagePatterns` with regex-form `matchPackageNames`; collapse the two k8s rules into one
- `go.json`: add `test-libraries` group (ginkgo + gomega), `go-toolchain` group (go.mod directive + `golang` Docker image + `setup-go`), and a regex `customManager` that picks up `go-version` inputs on reusable-workflow calls
- `base.json`: set `commitMessagePrefix: "chore(deps):"` and `branchPrefix: "renovate/"` so dep bumps don't surface as `fix(deps):` and trigger spurious PATCH releases
- README: refresh preset descriptions

Closes #2
Closes #3

## Notes
- Used `fileMatch` on the customManager (not `managerFilePatterns`). `managerFilePatterns` is the newer name in Renovate v40+, but `fileMatch` is accepted by both old and new versions and matches what issue #2 proposed. Worth a follow-up to migrate once consumer Renovate versions are confirmed >= v40.
- `base.json` already had `semanticCommitType: "chore"` + `semanticCommitScope: "deps"`. Adding the explicit `commitMessagePrefix` makes the intent unambiguous and overrides any consumer that disables `:semanticCommits`.
- Validated locally with `npx renovate-config-validator base.json go.json kubernetes.json` → \`Config validated successfully\`.

## Test plan
- [ ] CI lint job passes (JSON validation)
- [ ] After merge, watch one Renovate run on `cloudflare-operator` (or any consumer) — confirm:
  - [ ] PR title / branch / commit use `chore(deps):` and `renovate/`
  - [ ] `k8s.io/*` + `controller-runtime` bumps land in a single grouped PR
  - [ ] ginkgo + gomega bumps land in one PR
  - [ ] `go.mod` toolchain, `golang` Docker image, and `setup-go` `go-version` (including reusable-workflow inputs) land in one grouped PR
  - [ ] semantic-release does not cut a PATCH on dep-only merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)